### PR TITLE
feat: add basic auth to protect docs endpoint

### DIFF
--- a/examples/vinejs-example/app/controllers/files_controller.ts
+++ b/examples/vinejs-example/app/controllers/files_controller.ts
@@ -1,11 +1,6 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import vine from '@vinejs/vine'
-import {
-  SwaggerInfo,
-  SwaggerResponse,
-  SwaggerRequestBody,
-  vineFile,
-} from 'adonis-open-swagger'
+import { SwaggerInfo, SwaggerResponse, SwaggerRequestBody, vineFile } from 'adonis-open-swagger'
 
 export default class FilesController {
   @SwaggerInfo({
@@ -54,4 +49,3 @@ export default class FilesController {
     })
   }
 }
-

--- a/src/middleware/swagger_middleware.ts
+++ b/src/middleware/swagger_middleware.ts
@@ -1,14 +1,30 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
+import type { Request } from '@adonisjs/core/http'
+import type { OpenSwaggerConfig } from '../types.js'
+import { timingSafeEqual } from 'node:crypto'
 
 /**
  * Middleware for Swagger documentation routes
+ * Handles CORS, security headers, and optional basic authentication
  */
 export default class SwaggerMiddleware {
+  constructor(private config: OpenSwaggerConfig) {}
+
   /**
    * Handle the request
    */
   async handle(ctx: HttpContext, next: NextFn) {
+    // Check basic auth if enabled
+    if (this.config.basicAuth?.enabled) {
+      if (!this.validateBasicAuth(ctx.request)) {
+        const realm = this.config.basicAuth.realm || 'API Documentation'
+        ctx.response.header('WWW-Authenticate', `Basic realm="${realm}"`)
+        ctx.response.status(401)
+        return ctx.response.send('Unauthorized')
+      }
+    }
+
     // Add CORS headers for API documentation
     ctx.response.header('Access-Control-Allow-Origin', '*')
     ctx.response.header('Access-Control-Allow-Methods', 'GET, OPTIONS')
@@ -26,5 +42,51 @@ export default class SwaggerMiddleware {
     }
 
     await next()
+  }
+
+  /**
+   * Validate basic authentication credentials
+   * Uses timing-safe comparison to prevent timing attacks
+   */
+  private validateBasicAuth(request: Request): boolean {
+    const authHeader = request.header('authorization')
+    if (!authHeader?.startsWith('Basic ')) {
+      return false
+    }
+
+    try {
+      const base64Credentials = authHeader.slice(6)
+      const credentials = Buffer.from(base64Credentials, 'base64').toString('utf-8')
+      const colonIndex = credentials.indexOf(':')
+
+      if (colonIndex === -1) {
+        return false
+      }
+
+      const username = credentials.slice(0, colonIndex)
+      const password = credentials.slice(colonIndex + 1)
+
+      const expectedUsername = this.config.basicAuth!.username
+      const expectedPassword = this.config.basicAuth!.password
+
+      // Use timing-safe comparison to prevent timing attacks
+      const usernameBuffer = Buffer.from(username)
+      const expectedUsernameBuffer = Buffer.from(expectedUsername)
+      const passwordBuffer = Buffer.from(password)
+      const expectedPasswordBuffer = Buffer.from(expectedPassword)
+
+      // Check lengths first, then do timing-safe comparison
+      const usernameMatch =
+        usernameBuffer.length === expectedUsernameBuffer.length &&
+        timingSafeEqual(usernameBuffer, expectedUsernameBuffer)
+
+      const passwordMatch =
+        passwordBuffer.length === expectedPasswordBuffer.length &&
+        timingSafeEqual(passwordBuffer, expectedPasswordBuffer)
+
+      return usernameMatch && passwordMatch
+    } catch {
+      return false
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,36 @@ export interface ComponentsConfig {
 }
 
 /**
+ * Basic authentication configuration for docs endpoints
+ * Protects /docs, /docs/json, /docs/yaml from unauthorized access
+ */
+export interface BasicAuthConfig {
+  /**
+   * Enable basic authentication for docs endpoints
+   * @default false
+   */
+  enabled: boolean
+
+  /**
+   * Username for basic auth
+   * Supports env() helper for environment variables
+   */
+  username: string
+
+  /**
+   * Password for basic auth
+   * Supports env() helper for environment variables
+   */
+  password: string
+
+  /**
+   * Realm name shown in browser auth dialog
+   * @default 'API Documentation'
+   */
+  realm?: string
+}
+
+/**
  * Configuration options for Open Swagger
  */
 export interface OpenSwaggerConfig {
@@ -192,6 +222,12 @@ export interface OpenSwaggerConfig {
    * Enable or disable the swagger documentation
    */
   enabled: boolean
+
+  /**
+   * Basic authentication for docs endpoints
+   * Protects documentation from unauthorized access in production
+   */
+  basicAuth?: BasicAuthConfig
 
   /**
    * Path where the documentation will be served

--- a/stubs/config/swagger.stub
+++ b/stubs/config/swagger.stub
@@ -1,6 +1,7 @@
 {{{
   exports({ to: app.configPath('swagger.ts') })
 }}}
+import env from '#start/env'
 import { defineConfig } from 'adonis-open-swagger'
 
 /**
@@ -11,6 +12,18 @@ export default defineConfig({
    * Enable or disable swagger documentation
    */
   enabled: true,
+
+  /**
+   * Basic authentication for docs endpoints
+   * Protects documentation from unauthorized access in production
+   * IMPORTANT: Use env() to read credentials from environment variables
+   */
+  // basicAuth: {
+  //   enabled: true,
+  //   username: env('SWAGGER_USERNAME', 'admin'),
+  //   password: env('SWAGGER_PASSWORD', 'secret'),
+  //   realm: 'API Documentation',
+  // },
 
   /**
    * Path where the documentation will be served

--- a/tests/swagger_middleware.spec.ts
+++ b/tests/swagger_middleware.spec.ts
@@ -1,0 +1,299 @@
+import { test } from '@japa/runner'
+import SwaggerMiddleware from '../src/middleware/swagger_middleware.js'
+import type { OpenSwaggerConfig } from '../src/types.js'
+
+/**
+ * Create a minimal config for testing
+ */
+function createConfig(basicAuth?: OpenSwaggerConfig['basicAuth']): OpenSwaggerConfig {
+  return {
+    enabled: true,
+    path: '/docs',
+    info: {
+      title: 'Test API',
+      version: '1.0.0',
+    },
+    scalar: {},
+    routes: {},
+    basicAuth,
+  }
+}
+
+/**
+ * Create a mock request object
+ */
+function createMockRequest(authHeader?: string) {
+  return {
+    header: (name: string) => {
+      if (name.toLowerCase() === 'authorization') {
+        return authHeader
+      }
+      return undefined
+    },
+    method: () => 'GET',
+  }
+}
+
+/**
+ * Create a mock response object
+ */
+function createMockResponse() {
+  const headers: Record<string, string> = {}
+  let statusCode = 200
+  let body: any = null
+
+  return {
+    header: (name: string, value: string) => {
+      headers[name] = value
+      return this
+    },
+    status: (code: number) => {
+      statusCode = code
+      return {
+        send: (data: any) => {
+          body = data
+        },
+      }
+    },
+    send: (data: any) => {
+      body = data
+    },
+    getHeaders: () => headers,
+    getStatus: () => statusCode,
+    getBody: () => body,
+  }
+}
+
+/**
+ * Create a mock HttpContext
+ */
+function createMockContext(authHeader?: string) {
+  const response = createMockResponse()
+  return {
+    request: createMockRequest(authHeader),
+    response,
+    _response: response,
+  }
+}
+
+/**
+ * Encode credentials to base64 Basic auth format
+ */
+function encodeBasicAuth(username: string, password: string): string {
+  const credentials = `${username}:${password}`
+  return `Basic ${Buffer.from(credentials).toString('base64')}`
+}
+
+test.group('SwaggerMiddleware - Basic Auth', () => {
+  test('allows access when basicAuth is disabled', async ({ assert }) => {
+    const config = createConfig()
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext()
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isTrue(nextCalled)
+  })
+
+  test('allows access when basicAuth is not configured', async ({ assert }) => {
+    const config = createConfig(undefined)
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext()
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isTrue(nextCalled)
+  })
+
+  test('returns 401 when no Authorization header is provided', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext()
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isFalse(nextCalled)
+    assert.equal(ctx._response.getHeaders()['WWW-Authenticate'], 'Basic realm="API Documentation"')
+  })
+
+  test('returns 401 with custom realm', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+      realm: 'Custom Realm',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext()
+
+    await middleware.handle(ctx as any, async () => {})
+
+    assert.equal(ctx._response.getHeaders()['WWW-Authenticate'], 'Basic realm="Custom Realm"')
+  })
+
+  test('returns 401 when credentials are invalid', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext(encodeBasicAuth('wrong', 'credentials'))
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isFalse(nextCalled)
+  })
+
+  test('returns 401 when only username is wrong', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext(encodeBasicAuth('wrong', 'secret'))
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isFalse(nextCalled)
+  })
+
+  test('returns 401 when only password is wrong', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext(encodeBasicAuth('admin', 'wrong'))
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isFalse(nextCalled)
+  })
+
+  test('allows access with valid credentials', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext(encodeBasicAuth('admin', 'secret'))
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isTrue(nextCalled)
+  })
+
+  test('handles password with colon character', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret:with:colons',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext(encodeBasicAuth('admin', 'secret:with:colons'))
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isTrue(nextCalled)
+  })
+
+  test('returns 401 for malformed Authorization header', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext('Bearer some-token')
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isFalse(nextCalled)
+  })
+
+  test('returns 401 for invalid base64 encoding', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext('Basic not-valid-base64!!!')
+
+    let nextCalled = false
+    await middleware.handle(ctx as any, async () => {
+      nextCalled = true
+    })
+
+    assert.isFalse(nextCalled)
+  })
+
+  test('adds security headers when auth passes', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext(encodeBasicAuth('admin', 'secret'))
+
+    await middleware.handle(ctx as any, async () => {})
+
+    const headers = ctx._response.getHeaders()
+    assert.equal(headers['X-Content-Type-Options'], 'nosniff')
+    assert.equal(headers['X-Frame-Options'], 'DENY')
+    assert.equal(headers['X-XSS-Protection'], '1; mode=block')
+  })
+
+  test('adds CORS headers when auth passes', async ({ assert }) => {
+    const config = createConfig({
+      enabled: true,
+      username: 'admin',
+      password: 'secret',
+    })
+    const middleware = new SwaggerMiddleware(config)
+    const ctx = createMockContext(encodeBasicAuth('admin', 'secret'))
+
+    await middleware.handle(ctx as any, async () => {})
+
+    const headers = ctx._response.getHeaders()
+    assert.equal(headers['Access-Control-Allow-Origin'], '*')
+    assert.equal(headers['Access-Control-Allow-Methods'], 'GET, OPTIONS')
+    assert.equal(headers['Access-Control-Allow-Headers'], 'Content-Type, Authorization')
+  })
+})


### PR DESCRIPTION
## Usage
To enable basic auth, add this to your `config/swagger.ts`:
```
basicAuth: {
  enabled: true,
  username: env('SWAGGER_USERNAME', 'admin'),
  password: env('SWAGGER_PASSWORD', 'secret'),
  realm: 'API Documentation',
},
```