### PR TITLE
fix: add AdonisJS v7 compatibility

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -1,9 +1,8 @@
 import 'reflect-metadata'
-import { getDirname } from '@adonisjs/core/helpers'
 import type Configure from '@adonisjs/core/commands/configure'
 
 // Get the stubs directory path
-const stubsRoot = getDirname(import.meta.url) + '/stubs'
+const stubsRoot = import.meta.dirname + '/stubs'
 
 /**
  * Configure command for Open Swagger package

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adonis-open-swagger",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": false,
   "description": "Modern Swagger/OpenAPI integration for AdonisJS v6 with Scalar UI",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adonis-open-swagger",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": false,
   "description": "Modern Swagger/OpenAPI integration for AdonisJS v6 with Scalar UI",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "adonis-open-swagger",
   "version": "1.5.4",
   "private": false,
-  "description": "Modern Swagger/OpenAPI integration for AdonisJS v6 with Scalar UI",
+  "description": "Modern Swagger/OpenAPI integration for AdonisJS v6/v7 with Scalar UI",
   "type": "module",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -114,8 +114,8 @@
     "zod": "^4.1.8"
   },
   "peerDependencies": {
-    "@adonisjs/core": "^6.2.0",
-    "@vinejs/vine": "^2.0.0 || ^3.0.0"
+    "@adonisjs/core": "^6.2.0 || ^7.0.0",
+    "@vinejs/vine": ">=2.0.0"
   },
   "peerDependenciesMeta": {
     "@sinclair/typebox": {


### PR DESCRIPTION
## Summary

- Replace `getDirname(import.meta.url)` with `import.meta.dirname` in `configure.ts` — `getDirname` was removed from `@adonisjs/core/helpers` in v7
- Widen `@adonisjs/core` peer dep to `^6.2.0 || ^7.0.0`
- Widen `@vinejs/vine` peer dep to `>=2.0.0` (AdonisJS v7 ships with Vine v4)

## Context

AdonisJS v7 removed several helpers from `@adonisjs/core/helpers`, including `getDirname` and `getFilename`. The replacement is the native `import.meta.dirname` (available since Node 21.2, and AdonisJS v7 requires Node >= 24).

The only affected file is `configure.ts` — the rest of the package source (`src/`, `providers/`, `commands/`) uses no removed APIs.

## Test plan

- [x] Verified the fix resolves the runtime crash when using `adonis-open-swagger` with `@adonisjs/core@7.3.1`
- [ ] Run `npm run build` to confirm the package compiles
- [ ] Run `npm run test` to confirm existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)